### PR TITLE
Allow a greater object offset

### DIFF
--- a/display_api/API.md
+++ b/display_api/API.md
@@ -49,7 +49,10 @@ This is a helper to register entities used for display.
 ### Display_entities fields
 `on_display_update` is a callback in charge of setting up entity texture. If not set, entity will have no texture and will be displayed as unknown item.
 
-`depth`, `right` and `heigh` : Entity position regarding to node facedir/wallmounted main axis. Values for these fields can be any number between -0.5 and 0.5 (default value is 0). Position 0,0,0 is the center of the node. `depth` goes from front (-0.5) to rear (0.5), `height` goes from bottom (-0.5) to top (0.5) and `right` goes from left (-0.5) to right (0.5).
+`depth`, `right` and `height` : Entity position regarding to node facedir/wallmounted main axis.
+Values for these fields can be any number between -1.5 and 1.5 (default value is 0).
+Position 0,0,0 is the center of the node.
+`depth` goes from front (-0.5) to rear (0.5), `height` goes from bottom (-0.5) to top (0.5) and `right` goes from left (-0.5) to right (0.5).
 
 In order to avoid flickering text, it's better to have text a little behind node surface. A good spacing value is given by `display_api.entity_spacing` variable.
 


### PR DESCRIPTION
This allows e.g. polemounted signs.
Required for display_modpack to be usable in the streets mod.
Backwards compatible.