### PR TITLE
Optional parsing of UTF entities.

### DIFF
--- a/boards/init.lua
+++ b/boards/init.lua
@@ -22,6 +22,14 @@ boards = {}
 boards.name = minetest.get_current_modname()
 boards.path = minetest.get_modpath(boards.name)
 
+-- Load support for utfparse
+local UParse
+if minetest.global_exists("utfparse") then
+	UParse = function(...) return utfparse.parse(...) end
+else
+	UParse = function(...) return ... end
+end
+
 -- Load support for intllib.
 local S, NS = dofile(boards.path.."/intllib.lua")
 boards.intllib = S
@@ -43,7 +51,7 @@ end
 local function on_receive_fields(pos, formname, fields, player)
 	if fields then
 		if fields.ok or fields.key_enter then
-			signs_api.set_display_text(pos, fields.display_text, fields.font)
+			signs_api.set_display_text(pos, UParse(fields.display_text), fields.font)
 		end
 		if fields.wipe then
 			signs_api.set_display_text(pos, "", fields.font)

--- a/signs/init.lua
+++ b/signs/init.lua
@@ -26,6 +26,15 @@ signs.path = minetest.get_modpath(signs.name)
 local S, NS = dofile(signs.path.."/intllib.lua")
 signs.intllib = S
 
+-- Load support for utfparse
+local UParse
+if minetest.global_exists("utfparse") then
+	UParse = function(...) return utfparse.parse(...) end
+else
+	UParse = function(...) return ... end
+end
+signs.utfparse = UParse
+
 dofile(signs.path.."/common.lua")
 dofile(signs.path.."/nodes.lua")
 dofile(signs.path.."/crafts.lua")

--- a/signs/mod.conf
+++ b/signs/mod.conf
@@ -1,4 +1,4 @@
 name=signs
 description=Basic signs and posters with text display using signs_api
 depends=default,dye,signs_api
-optional_depends=intllib
+optional_depends=intllib,utfparse

--- a/signs/nodes.lua
+++ b/signs/nodes.lua
@@ -18,6 +18,7 @@
     along with signs.  If not, see <http://www.gnu.org/licenses/>.
 --]]
 
+local UParse = signs.utfparse
 local S = signs.intllib
 local F = function(...) return minetest.formspec_escape(S(...)) end
 
@@ -91,9 +92,9 @@ local function on_receive_fields_poster(pos, formname, fields, player)
 		if formname == node.name.."@"..minetest.pos_to_string(pos)..":edit"
 		then
 			if (fields.write or fields.font or fields.key_enter) then
-				meta:set_string("display_text", fields.display_text)
-				meta:set_string("text", fields.text)
-				meta:set_string("infotext", "\""..fields.display_text
+				meta:set_string("display_text", UParse(fields.display_text))
+				meta:set_string("text", UParse(fields.text))
+				meta:set_string("infotext", "\""..UParse(fields.display_text)
 						.."\"\n"..S("(right-click to read more text)"))
 				display_api.update_entities(pos)
 			end

--- a/signs_api/init.lua
+++ b/signs_api/init.lua
@@ -22,6 +22,15 @@ signs_api = {}
 signs_api.name = minetest.get_current_modname()
 signs_api.path = minetest.get_modpath(signs_api.name)
 
+-- Load support for utfparse
+local UParse
+if minetest.global_exists("utfparse") then
+	UParse = function(...) return utfparse.parse(...) end
+else
+	UParse = function(...) return ... end
+end
+signs_api.utfparse = UParse
+
 -- Load support for intllib.
 local S, NS = dofile(signs_api.path.."/intllib.lua")
 signs_api.intllib = S
@@ -77,10 +86,10 @@ end
 function signs_api.on_receive_fields(pos, formname, fields, player)
 	if not minetest.is_protected(pos, player:get_player_name()) then
 		if fields and (fields.ok or fields.key_enter) then
-			signs_api.set_display_text(pos, fields.display_text)
+			signs_api.set_display_text(pos, UParse(fields.display_text))
 		end
 		if fields and (fields.font) then
-			signs_api.set_display_text(pos, fields.display_text)
+			signs_api.set_display_text(pos, UParse(fields.display_text))
 			font_api.show_font_list(player, pos)
 		end
 	end

--- a/signs_api/mod.conf
+++ b/signs_api/mod.conf
@@ -1,4 +1,4 @@
 name=signs_api
 description=A library providing various helper functions for registereing signs with text display
 depends=default,display_api,font_api
-optional_depends=intllib
+optional_depends=intllib,utfparse

--- a/steles/init.lua
+++ b/steles/init.lua
@@ -25,6 +25,14 @@ steles.path = minetest.get_modpath(steles.name)
 -- Load support for intllib.
 local S, NS = dofile(steles.path.."/intllib.lua")
 steles.intllib = S
+-- Load support for utfparse
+local UParse
+if minetest.global_exists("utfparse") then
+	UParse = function(...) return utfparse.parse(...) end
+else
+	UParse = function(...) return ... end
+end
+steles.utfparse = UParse
 
 dofile(steles.path.."/config.lua")
 dofile(steles.path.."/nodes.lua")

--- a/steles/mod.conf
+++ b/steles/mod.conf
@@ -1,4 +1,4 @@
 name=steles
 description=Stone steles with text display on them
 depends=default,display_api,font_api
-optional_depends=intllib,technic
+optional_depends=intllib,technic,utfparse

--- a/steles/nodes.lua
+++ b/steles/nodes.lua
@@ -18,6 +18,7 @@
     along with steles.  If not, see <http://www.gnu.org/licenses/>.
 --]]
 
+local UParse = steles.utfparse
 local S = steles.intllib
 local F = function(...) return minetest.formspec_escape(S(...)) end
 
@@ -79,8 +80,8 @@ for i, material in ipairs(steles.materials) do
 					if not minetest.is_protected(pos, player:get_player_name()) then
 						local meta = minetest.get_meta(pos)
 						if fields.ok or fields.font then
-							meta:set_string("display_text", fields.display_text)
-							meta:set_string("infotext", "\""..fields.display_text.."\"")
+							meta:set_string("display_text", UParse(fields.display_text))
+							meta:set_string("infotext", "\""..UParse(fields.display_text).."\"")
 							display_api.update_entities(pos)
 						end
 						if fields.font then


### PR DESCRIPTION
So this ended up impacting more files than my previous PR proposal, but I feel in a lighter way as it just proposes an optional parsing at the beginning of `on_receive_fields(...)` functions. It adds an optional dependency to a [mod](https://github.com/yquemener/utfparse) that is basically one function, `utfparse.parse(text)`, that I will probably need to use a lot until Irrlicht's UI is fixed.

If you don't like adding a dependency, I can just add the function in a file but it will need to be repeated in each mod that provides `on_receive_fields(...)` functions.

