### PR TITLE
Add missing entries to wallmounted_rotations

### DIFF
--- a/display_api/display.lua
+++ b/display_api/display.lua
@@ -29,6 +29,7 @@ local wallmounted_rotations = {
 	[0]={x=1, y=0, z=0}, [1]={x=3, y=0, z=0},
 	[2]={x=0, y=3, z=0}, [3]={x=0, y=1, z=0},
 	[4]={x=0, y=0, z=0}, [5]={x=0, y=2, z=0},
+	[6]={x=1, y=0, z=0}, [7]={x=1, y=1, z=1},
 }
 
 local facedir_rotations = {


### PR DESCRIPTION
This adds missing values in `wallmounted_values` for param2 values 6, 14, 22, 7, 15, and 23 (previously these values caused a crash).

Test results look fine for each value:

![param2 6](https://user-images.githubusercontent.com/51716565/71394704-bf439200-25e0-11ea-9e2f-6d66c0d70636.png)

![param2 14](https://user-images.githubusercontent.com/51716565/71394740-dda98d80-25e0-11ea-9c8b-edcd9b2a347f.png)

![param2 22](https://user-images.githubusercontent.com/51716565/71394742-e13d1480-25e0-11ea-97b4-2e69ff9311eb.png)

![param2 7](https://user-images.githubusercontent.com/51716565/71394743-e4380500-25e0-11ea-81d2-e36142dc4d46.png)

![param2 15](https://user-images.githubusercontent.com/51716565/71394746-e732f580-25e0-11ea-99f8-e51419f72f1e.png)

![param2 23](https://user-images.githubusercontent.com/51716565/71394750-e9954f80-25e0-11ea-9cd5-dc8b28a58182.png)
