### PR TITLE
Override on_punch for poster node definition

### DIFF
--- a/signs/nodes.lua
+++ b/signs/nodes.lua
@@ -210,6 +210,9 @@ local models = {
 			on_construct = display_api.on_construct,
 			on_rightclick = display_poster,
 			on_receive_fields = on_receive_fields_poster,
+			on_punch = function(pos, node, player, pointed_thing)
+				display_api.update_entities(pos)
+			end,
 		},
 	},
 	label_small = {


### PR DESCRIPTION
The signs_api `register_sign`'s default `on_punch` sets a sign's formspec to the sign editor. If we protect a poster and then punch/break it, subsequent attempts to view the poster will briefly cause the the sign editor to display before the actual poster formspec. Small, but annoying.