### PR TITLE
Delete .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "display_api"]
-	path = display_api
-	url = https://github.com/pyrollo/display_api.git


### PR DESCRIPTION
This PR removes the `.gitmodules` file because it looks like you've added the submodule in question already as a "hard" folder :thinking: 

Related: https://github.com/minetest/contentdb/issues/245