### PR TITLE
handle interactions w/ explosions

### DIFF
--- a/display_api/display.lua
+++ b/display_api/display.lua
@@ -289,6 +289,16 @@ function display_api.on_destruct(pos)
 	end
 end
 
+function display_api.on_blast(pos, intensity)
+	if not minetest.is_protected(pos, "tnt:blast") then
+		local node = minetest.get_node(pos)
+		local drops = minetest.get_node_drops(node, "tnt:blast")
+		minetest.remove_node(pos)
+		display_api.on_destruct(pos)
+		return drops
+	end
+end
+
 -- On_rotate (screwdriver) callback for display_api items. Prevents invalid
 -- rotations and reorients entities.
 function display_api.on_rotate(pos, node, user, _, new_param2)

--- a/display_api/display.lua
+++ b/display_api/display.lua
@@ -294,7 +294,6 @@ function display_api.on_blast(pos, intensity)
 		local node = minetest.get_node(pos)
 		local drops = minetest.get_node_drops(node, "tnt:blast")
 		minetest.remove_node(pos)
-		display_api.on_destruct(pos)
 		return drops
 	end
 end

--- a/display_api/display.lua
+++ b/display_api/display.lua
@@ -81,9 +81,16 @@ end
 -- Detect rotation restriction
 local rotation_restricted = nil
 minetest.register_entity('display_api:dummy_entity', {
-	collisionbox = { 0, 0, 0, 0, 0, 0 },
-	visual = "upright_sprite",
-	textures = {} })
+	initial_properties = {
+		collisionbox = {0, 0, 0, 0, 0, 0},
+		visual = "upright_sprite",
+		is_visible = false,
+		textures = {"blank.png"}
+	},
+	on_blast = function(self, damage)
+		return false, false, {}
+	end,
+})
 
 function display_api.is_rotation_restricted()
 	if rotation_restricted == nil then
@@ -304,12 +311,17 @@ end
 function display_api.register_display_entity(entity_name)
 	if not minetest.registered_entities[entity_name] then
 		minetest.register_entity(':'..entity_name, {
-			collisionbox = { 0, 0, 0, 0, 0, 0 },
-			visual = "upright_sprite",
-			textures = {},
+			initial_properties = {
+				collisionbox = {0, 0, 0, 0, 0, 0},
+				visual = "upright_sprite",
+				textures = {},
+			},
 			on_activate = display_api.on_activate,
 			get_staticdata = function(self)
 				return minetest.serialize({ nodepos = self.nodepos })
+			end,
+			on_blast = function(self, damage)
+				return false, false, {}
 			end,
 		})
 	end

--- a/ontime_clocks/nodes.lua
+++ b/ontime_clocks/nodes.lua
@@ -48,6 +48,7 @@ minetest.register_node("ontime_clocks:green_digital", {
 	on_place = display_api.on_place,
 	on_construct = display_api.on_construct,
 	on_destruct = display_api.on_destruct,
+	on_blast = display_api.on_blast,
 	on_rotate = display_api.on_rotate,
 })
 
@@ -86,6 +87,7 @@ minetest.register_node("ontime_clocks:red_digital", {
 	on_place = display_api.on_place,
 	on_construct = display_api.on_construct,
 	on_destruct = display_api.on_destruct,
+	on_blast = display_api.on_blast,
 	on_rotate = display_api.on_rotate,
 })
 
@@ -124,6 +126,7 @@ minetest.register_node("ontime_clocks:white", {
 	on_place = display_api.on_place,
 	on_construct = display_api.on_construct,
 	on_destruct = display_api.on_destruct,
+	on_blast = display_api.on_blast,
 	on_rotate = display_api.on_rotate,
 })
 
@@ -161,6 +164,7 @@ minetest.register_node("ontime_clocks:frameless_black", {
 	on_place = display_api.on_place,
 	on_construct = display_api.on_construct,
 	on_destruct = display_api.on_destruct,
+	on_blast = display_api.on_blast,
 	on_rotate = display_api.on_rotate,
 })
 
@@ -198,6 +202,7 @@ minetest.register_node("ontime_clocks:frameless_gold", {
 	on_place = display_api.on_place,
 	on_construct = display_api.on_construct,
 	on_destruct = display_api.on_destruct,
+	on_blast = display_api.on_blast,
 	on_rotate = display_api.on_rotate,
 })
 
@@ -235,6 +240,7 @@ minetest.register_node("ontime_clocks:frameless_white", {
 	on_place = display_api.on_place,
 	on_construct = display_api.on_construct,
 	on_destruct = display_api.on_destruct,
+	on_blast = display_api.on_blast,
 	on_rotate = display_api.on_rotate,
 })
 

--- a/signs/compatibility.lua
+++ b/signs/compatibility.lua
@@ -61,9 +61,11 @@ minetest.register_lbm({ name = "signs:conpatibility_1",
 -- We need to have this entity registered to be able to remove it.
 if minetest.registered_entities["signs:text"] == nil then
 	minetest.register_entity("signs:text", {
-		collisionbox = { 0, 0, 0, 0, 0, 0 },
-		visual = "upright_sprite",
-		textures = {},
+		on_activate = function(self)
+			if self.object then
+				self.object:remove()
+			end
+		end
 	})
 end
 

--- a/signs_api/init.lua
+++ b/signs_api/init.lua
@@ -218,6 +218,7 @@ function signs_api.register_sign(mod, name, model)
 				display_api.on_construct(pos)
 			end,
 		on_destruct = display_api.on_destruct,
+		on_blast = display_api.on_blast,
 		on_rotate = signs_api.on_rotate,
 		on_receive_fields =  signs_api.on_receive_fields,
 		on_punch = function(pos, node, player, pointed_thing)

--- a/steles/nodes.lua
+++ b/steles/nodes.lua
@@ -74,6 +74,7 @@ for i, material in ipairs(steles.materials) do
 					display_api.on_construct(pos)
 				end,
 			on_destruct = display_api.on_destruct,
+			on_blast = display_api.on_blast,
 			on_rotate = display_api.on_rotate,
 			on_receive_fields = function(pos, formname, fields, player)
 					if not minetest.is_protected(pos, player:get_player_name()) then


### PR DESCRIPTION
1. sign entities shouldn't be destroyed by explosions if the sign isn't destroyed
2. sign entities (and node metadata) should be removed if the sign is destroyed by an explosion.